### PR TITLE
Rename parameter to follow naming conventions

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/Password.java
@@ -44,8 +44,8 @@ public class Password {
         return parameters;
     }
 
-    boolean hasParameter(String TITLE) {
-        return parameters.containsKey(TITLE);
+    boolean hasParameter(String title) {
+        return parameters.containsKey(title);
     }
     
     public Parameter getParameter(String t) {


### PR DESCRIPTION
Přejmenován parametr metody `hasParameter` dle konvencí.

Jan Franta