### PR TITLE
Přidán modifikátor přístupu u metody hasParameter

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/Password.java
@@ -17,7 +17,7 @@ public record Password(int id, String password, HashMap<String, Parameter> param
         this(id, password, new HashMap<>());
     }
 
-    boolean hasParameter(String title) {
+    public boolean hasParameter(String title) {
         return parameters.containsKey(title);
     }
 


### PR DESCRIPTION
Modifikátor byl přidán, aby struktura kódu byla konzistentí (ve zbytku třídy i v ostatních třídách jsou modifikátory napsány)

Zároveň by měla být metoda přístupná veřejně (public) a né pouze v rámci balíčku (výchozí přistup v Javě), aby ji bylo možné využívat i mimo balíček.

Při ponechání přistupnosti v rámci balíčku je také zobrazováno upozornění na zbytočnost parametru, protože se v rámci aktuálního baličku používá pouze pro kontrolu parametru TITLE, k čemuž není nutné mít parametrizovanou metodu, v případě zvěřejnění (public) této metody mužeme metodu využívat i mimo balíček a využívat různé parametry.

