### PR TITLE
Fix title comparison in findEntryByTitle method

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/PasswordDatabase.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/PasswordDatabase.java
@@ -55,7 +55,7 @@ public class PasswordDatabase {
             if (password.hasParameter(Parameter.StandardizedParameters.TITLE)) {
                 Parameter.TextParameter titleParam;
                 titleParam = (Parameter.TextParameter)password.getParameter(Parameter.StandardizedParameters.TITLE);
-                if (titleParam.getValue().equals(titleParam)) {
+                if (titleParam.getValue().equals(title)) {
                     return password;
                 }
             }


### PR DESCRIPTION
Fix incorrect title comparison in findEntryByTitle method to return the correct password entry based on title.
Because findEntryByTitle always returned false due to comparing a parameter's value with the parameter object itself.

Maksym Hriha