### PR TITLE
Use constants instead hardcoded strings

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/JsonConverter.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/JsonConverter.java
@@ -10,6 +10,10 @@ import java.util.HashMap;
  */
 public class JsonConverter {
 
+    private static final String KEY_ID = "id";
+    private static final String KEY_PASSWORD = "password";
+    private static final String KEY_PARAMETERS = "parameters";
+
     public String toJson(List<Password> passwords) {
         StringBuilder output = new StringBuilder("[");
         for (int i = 0; i < passwords.size(); i++) {
@@ -17,12 +21,12 @@ public class JsonConverter {
 
             Password password = passwords.get(i);
             output.append("{")
-                    .append("id:").append(password.id()).append(",")
-                    .append("password:\"").append(password.password()).append("\"");
+                    .append(KEY_ID).append(":").append(password.id()).append(",")
+                    .append(KEY_PASSWORD).append(":\"").append(password.password()).append("\"");
 
             HashMap<String, Parameter> parameters = password.parameters();
             if (parameters != null && !parameters.isEmpty()) {
-                output.append(",parameters:{");
+                output.append(",").append(KEY_PARAMETERS).append(":{");
                 int count = 0;
                 for (String key : parameters.keySet()) {
                     if (count > 0) output.append(",");
@@ -72,20 +76,20 @@ public class JsonConverter {
             i = keyEnd + 2; // Move past key and ':'
 
             switch (key) {
-                case "id":
+                case KEY_ID:
                     int idEnd = json.indexOf(",", i);
                     id = Integer.parseInt(json.substring(i, idEnd).trim());
                     i = idEnd + 1; // Move past id value and ','
                     break;
 
-                case "password":
+                case KEY_PASSWORD:
                     int passwordStart = json.indexOf("\"", i) + 1;
                     int passwordEnd = json.indexOf("\"", passwordStart);
                     passwordValue = json.substring(passwordStart, passwordEnd);
                     i = passwordEnd + 1; // Move past password value and ','
                     break;
 
-                case "parameters":
+                case KEY_PARAMETERS:
                     i++; // Move past '{'
                     parameters = parseParameters(json, i);
                     // Move i to '}'


### PR DESCRIPTION
Use constants for JSON keys "id", "password" and "parameters", which are hardcoded, to avoid typos and enable reuse.