### PR TITLE
Fix JSON formatting and adjust test validation for correct key quoting

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/JsonConverter.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/JsonConverter.java
@@ -21,16 +21,16 @@ public class JsonConverter {
 
             Password password = passwords.get(i);
             output.append("{")
-                    .append(KEY_ID).append(":").append(password.id()).append(",")
-                    .append(KEY_PASSWORD).append(":\"").append(password.password()).append("\"");
+                    .append("\"").append(KEY_ID).append("\":").append(password.id()).append(",")
+                    .append("\"").append(KEY_PASSWORD).append("\":\"").append(password.password()).append("\"");
 
             HashMap<String, Parameter> parameters = password.parameters();
             if (parameters != null && !parameters.isEmpty()) {
-                output.append(",").append(KEY_PARAMETERS).append(":{");
+                output.append(",\"").append(KEY_PARAMETERS).append("\":{");
                 int count = 0;
                 for (String key : parameters.keySet()) {
                     if (count > 0) output.append(",");
-                    output.append(key).append(":").append(parameters.get(key).toJson());
+                    output.append("\"").append(key).append("\":").append(parameters.get(key).toJson());
                     count++;
                 }
                 output.append("}");

--- a/src/test/java/cz/upce/fei/nnptp/zz/entity/JSONTest.java
+++ b/src/test/java/cz/upce/fei/nnptp/zz/entity/JSONTest.java
@@ -25,7 +25,7 @@ public class JSONTest {
         List<Password> passwords = new ArrayList<>();
         passwords.add(new Password(1, "password123"));
         String result = json.toJson(passwords);
-        assertEquals("[{id:1,password:\"password123\"}]", result, "Expected JSON for a single password without parameters.");
+        assertEquals("[{\"id\":1,\"password\":\"password123\"}]", result, "Expected JSON for a single password without parameters.");
     }
     @Test
     public void testToJsonMultiplePasswordsWithParameters() {
@@ -41,8 +41,8 @@ public class JSONTest {
         passwords.add(new Password(2, "password456", parameters2));
 
         String result = json.toJson(passwords);
-        assertEquals("[{id:1,password:\"password123\",parameters:{title:\"Title\"}},"
-                        + "{id:2,password:\"password456\",parameters:{expiration-datetime:\"2024-11-10T23:50\",website:\"https://www.upce.cz/\"}}]",
+        assertEquals("[{\"id\":1,\"password\":\"password123\",\"parameters\":{\"title\":\"Title\"}},"
+                        + "{\"id\":2,\"password\":\"password456\",\"parameters\":{\"expiration-datetime\":\"2024-11-10T23:50\",\"website\":\"https://www.upce.cz/\"}}]",
                 result, "Expected JSON for multiple passwords with parameters.");
     }
     @Test


### PR DESCRIPTION
- Fixed JSON formatting in the `toJson` method to ensure all keys, including "parameters" and nested keys, are properly enclosed in quotes as required by the JSON standard.
- Updated tests `testToJson*` to correctly validate the JSON output with quoted keys.

Maksym Hriha