### PR TITLE
prevent NullPointerException when closing FileInputStream in finally block

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/CryptoFile.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/CryptoFile.java
@@ -50,7 +50,9 @@ public class CryptoFile {
             Logger.getLogger(CryptoFile.class.getName()).log(Level.SEVERE, null, ex);
         } finally {
             try {
-                fis.close();
+                if(fis != null){
+                    fis.close();
+                }
             } catch (IOException ex) {
                 Logger.getLogger(CryptoFile.class.getName()).log(Level.SEVERE, null, ex);
             }


### PR DESCRIPTION
Added a null check for the FileInputStream (fis) in the finally block to ensure that close() is not called on a null object. This prevents a potential NullPointerException in cases where the FileInputStream initialization fails and the code still reaches the finally block.

Lukáš Bajer, st60970