### PR TITLE
Removed unused methods and related imports

### DIFF
--- a/src/test/java/cz/upce/fei/nnptp/zz/entity/CryptoFileTest.java
+++ b/src/test/java/cz/upce/fei/nnptp/zz/entity/CryptoFileTest.java
@@ -3,10 +3,6 @@ package cz.upce.fei.nnptp.zz.entity;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 /**

--- a/src/test/java/cz/upce/fei/nnptp/zz/entity/CryptoFileTest.java
+++ b/src/test/java/cz/upce/fei/nnptp/zz/entity/CryptoFileTest.java
@@ -18,23 +18,6 @@ public class CryptoFileTest {
     
     public CryptoFileTest() {
     }
-    
-    @BeforeAll
-    public static void setUpClass() {
-    }
-    
-    @AfterAll
-    public static void tearDownClass() {
-    }
-    
-    @BeforeEach
-    public void setUp() {
-    }
-    
-    @AfterEach
-    public void tearDown() {
-    }
-
     /**
      * Test of readFile method, of class CryptoFile.
      *


### PR DESCRIPTION
Removed unused @BeforeAll, @AfterAll, @BeforeEach, and @AfterEach methods and related imports in CryptoFileTest class.
Author: David Polívka